### PR TITLE
Fix pdf text extraction

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "dorf-nelson-zauderer-confidential-assistant",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "autoprefixer": "^10.0.1",
         "docx": "^9.5.1",


### PR DESCRIPTION
Fix PDF text extraction by installing missing dependencies and updating the PDF worker file.

The PDF text extraction was failing because `pdfjs-dist` was not installed, and the `pdf.worker.min.js` file in `public/` was outdated. This PR resolves the issue by running `npm install` to get all dependencies, including `pdfjs-dist`, and then copying the correct `pdf.worker.min.mjs` from `node_modules` to `public/pdf.worker.min.js`. The `package-lock.json` is updated to reflect these dependency changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-325b3a53-c844-420b-a7cf-c429557d72f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-325b3a53-c844-420b-a7cf-c429557d72f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

