### PR TITLE
Fix pdf extractor object property definition error

### DIFF
--- a/PDF_EXTRACTION_FIXES.md
+++ b/PDF_EXTRACTION_FIXES.md
@@ -1,0 +1,185 @@
+# PDF Extraction Fixes - Implementation Summary
+
+## Problem
+PDFs were failing with the error: **"Object.defineProperty called on non-object"**
+
+Word documents (.docx) worked fine because they use a simple XML-based structure that's easy to parse, while PDFs are complex binary page-layout formats designed for visual rendering, not text extraction.
+
+## Root Causes
+1. **Invalid Object Handling**: PDF.js was receiving invalid or null objects during processing
+2. **Buffer Type Mismatches**: Improper conversion between ArrayBuffer and Uint8Array
+3. **Missing Validation**: No checks to ensure objects were valid before operations
+4. **Poor Error Handling**: Generic error messages without fallback guidance
+
+## Solutions Implemented
+
+### 1. Input Validation Before Processing ✅
+**Location**: Lines 101-150 in `InputBox.tsx`
+
+```typescript
+// Validate ArrayBuffer exists and is valid
+if (!result || !(result instanceof ArrayBuffer)) {
+  throw new Error('PDF file did not load as ArrayBuffer - file may be corrupted');
+}
+
+// Validate ArrayBuffer is not empty
+if (arrayBuffer.byteLength === 0) {
+  throw new Error('PDF file is empty (0 bytes)');
+}
+
+// Validate Uint8Array conversion
+if (!uint8Array || uint8Array.length === 0) {
+  throw new Error('Failed to convert PDF to Uint8Array');
+}
+
+// Validate PDF header signature
+const headerBytes = uint8Array.slice(0, 5);
+const headerString = String.fromCharCode.apply(null, Array.from(headerBytes));
+if (!headerString.startsWith('%PDF')) {
+  throw new Error('File does not appear to be a valid PDF format');
+}
+```
+
+### 2. Proper ArrayBuffer/Uint8Array Handling ✅
+**Location**: Lines 133-164 in `InputBox.tsx`
+
+```typescript
+// PROPER BUFFER HANDLING: Convert ArrayBuffer to Uint8Array
+// This ensures we pass the correct data type to PDF.js
+const uint8Array = new Uint8Array(arrayBuffer);
+
+// Pass data as Uint8Array with proper configuration
+loadingTask = pdfjsLib.getDocument({
+  data: uint8Array,
+  useSystemFonts: true,
+  verbosity: 0,
+  disableFontFace: false,
+  password: ''
+});
+```
+
+### 3. Object Validation at Every Step ✅
+**Location**: Lines 170-214 in `InputBox.tsx`
+
+```typescript
+// Validate loadingTask is a proper object
+if (typeof loadingTask !== 'object' || loadingTask === null) {
+  throw new Error('PDF loader returned invalid object');
+}
+
+// Validate PDF object
+if (typeof pdf !== 'object' || pdf === null) {
+  throw new Error('PDF document loaded but returned invalid object');
+}
+
+// Validate page object
+if (typeof page !== 'object' || page === null) {
+  throw new Error(`Page ${i} returned invalid object`);
+}
+
+// Validate textContent object
+if (typeof textContent !== 'object' || textContent === null || !Array.isArray(textContent.items)) {
+  console.warn(`Page ${i} has invalid text content structure`);
+  continue;
+}
+```
+
+### 4. Defensive Item Processing ✅
+**Location**: Lines 216-225 in `InputBox.tsx`
+
+```typescript
+const pageText = textContent.items
+  .map((item: any) => {
+    // Defensive check: ensure item has str property
+    if (item && typeof item === 'object' && typeof item.str === 'string') {
+      return item.str;
+    }
+    return '';
+  })
+  .join(' ')
+  .trim();
+```
+
+### 5. Comprehensive Error Handling with Specific Guidance ✅
+**Location**: Lines 249-276 in `InputBox.tsx`
+
+Added detailed error detection for:
+- **Worker loading issues**: Suggests refreshing page or clearing cache
+- **Invalid PDF format**: Verifies file is actually a PDF
+- **Password-protected PDFs**: Suggests removing protection
+- **Timeout errors**: Suggests splitting large PDFs
+- **Object.defineProperty errors**: Provides specific workarounds including:
+  - Export as Word (.docx) from Adobe Acrobat
+  - Save As to create new copy
+  - Copy/paste text directly
+  - Use online PDF-to-text converter
+
+### 6. Timeout Protection ✅
+**Location**: Lines 175-181 in `InputBox.tsx`
+
+```typescript
+// Load PDF document with timeout (30 seconds)
+const pdf = await Promise.race([
+  loadingTask.promise,
+  new Promise((_, reject) => 
+    setTimeout(() => reject(new Error('PDF loading timeout (30s)')), 30000)
+  )
+]) as any;
+```
+
+### 7. Image-Based PDF Detection ✅
+**Location**: Lines 242-248 in `InputBox.tsx`
+
+```typescript
+if (fullText.trim().length < 100) {
+  // Provides detailed guidance for scanned/image-based PDFs
+  // Suggests OCR solutions (Adobe Acrobat, ABBYY FineReader)
+  // Explains why text extraction failed
+}
+```
+
+## User-Friendly Error Messages
+
+All error messages now include:
+1. **Clear error description** with specific cause
+2. **Possible reasons** for the failure
+3. **Actionable workarounds** (numbered steps)
+4. **Alternative options** (Word upload, copy/paste)
+5. **Educational context** (why PDFs are harder than DOCX)
+
+## Testing Recommendations
+
+Test with various PDF types:
+- ✅ Standard text-based PDFs
+- ✅ Encrypted/password-protected PDFs
+- ✅ Scanned/image-based PDFs (OCR needed)
+- ✅ PDFs with XFA forms or multimedia
+- ✅ Malformed or corrupted PDFs
+- ✅ Very large PDFs (timeout protection)
+- ✅ Empty PDFs (0 bytes)
+
+## Benefits
+
+1. **Prevents crashes**: Validates all objects before use
+2. **Better UX**: Clear, actionable error messages
+3. **Graceful degradation**: Provides alternatives when extraction fails
+4. **Debugging**: Extensive console logging for troubleshooting
+5. **Edge case handling**: Covers password-protected, scanned, corrupted PDFs
+6. **Performance**: 30-second timeout prevents hanging
+
+## Why Word Documents Work Better
+
+As explained in the error messages:
+
+> Word documents (.docx) work more reliably because they use a structured XML format, while PDFs are designed for visual layout and can have complex encoding, embedded fonts, or image-based content that makes text extraction difficult.
+
+- **DOCX = ZIP archive of XML files**: Easy to parse structured content
+- **PDF = Binary page-layout format**: Optimized for rendering, not extraction
+
+## Next Steps (Optional Enhancements)
+
+1. **Add OCR fallback**: Integrate Tesseract.js for image-based PDFs
+2. **Alternative PDF library**: Consider pdf-parse or pdf2json as fallback
+3. **Server-side processing**: Move complex PDFs to backend with PDFBox
+4. **Progress indicator**: Show extraction progress for large PDFs
+5. **Unit tests**: Create test suite with various PDF types


### PR DESCRIPTION
Enhance PDF text extraction with robust input validation, error handling, and user-friendly fallback messages.

The "Object.defineProperty called on non-object" error occurred because PDF.js was attempting to operate on invalid or null objects, often due to the complex and varied internal structures of PDFs (e.g., image-only, encrypted, malformed). Unlike DOCX files which are structured XML, PDFs are binary page-layout formats, making reliable text extraction challenging without extensive validation and error recovery. This PR addresses these issues by adding comprehensive checks and providing actionable user guidance.

---
<a href="https://cursor.com/background-agent?bcId=bc-e832db2d-a8fa-4472-8a7f-8c1755bb2c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e832db2d-a8fa-4472-8a7f-8c1755bb2c4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

